### PR TITLE
Rename IDE_SHORT for PhpStorm

### DIFF
--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -48,7 +48,7 @@ jobs:
     uses: bpmct/jetbrains-indexer/.github/workflows/build-and-push.yaml@master
     with:
       IDE: PhpStorm
-      IDE_SHORT: pycharm
+      IDE_SHORT: phpstorm
       IDE_CODE: webide
     secrets:
       username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
The cli tool for PhpStorm is called `phpstorm.sh`.

Is this the reason why there are no phpstorm tags on DockerHub?